### PR TITLE
Use milliseconds in header

### DIFF
--- a/src/ServerTiming.php
+++ b/src/ServerTiming.php
@@ -86,13 +86,12 @@ class ServerTiming implements MiddlewareInterface
         $regex = "/[^[:alnum:]!#$%&\'*\/+\-.^_`|~]/";
         $header = "";
         foreach ($values as $description => $timing) {
-            $seconds = $timing / 1000;
             if (preg_match($regex, $description)) {
                 $token = preg_replace($regex, "", $description);
                 $token = strtolower(trim($token, "-"));
-                $header .= sprintf('%s=%01.3f; "%s", ', $token, $seconds, $description);
+                $header .= sprintf('%s=%01.3f; "%s", ', $token, $timing, $description);
             } else {
-                $header .= sprintf("%s=%01.3f, ", $description, $seconds);
+                $header .= sprintf("%s=%01.3f, ", $description, $timing);
             }
         };
         return $header = preg_replace("/, $/", "", $header);


### PR DESCRIPTION
The current code, which uses seconds in the header, results in some strange timings in (at least) Chrome's dev tools. It seems like milliseconds is what's expected.

**Before (using `$seconds`):**
![screen shot 2017-05-11 at 16 34 37](https://cloud.githubusercontent.com/assets/264300/25954940/10700b2e-3668-11e7-858e-3d06472a6280.png)

**After (using `$timing`):**
![screen shot 2017-05-11 at 16 33 47](https://cloud.githubusercontent.com/assets/264300/25954939/103f9e1c-3668-11e7-965d-e8b3ef203437.png)