### PR TITLE
Improve extensibility

### DIFF
--- a/src/ServerTiming.php
+++ b/src/ServerTiming.php
@@ -23,16 +23,17 @@ use Interop\Http\ServerMiddleware\DelegateInterface;
 
 use Tuupola\Middleware\ServerTiming\CallableDelegate;
 use Tuupola\Middleware\ServerTiming\Stopwatch;
+use Tuupola\Middleware\ServerTiming\StopwatchInterface;
 
 class ServerTiming implements MiddlewareInterface
 {
-    private $stopwatch;
+    protected $stopwatch;
     private $start;
     private $bootstrap = "Bootstrap";
     private $process = "Process";
     private $total = "Total";
 
-    public function __construct(Stopwatch $stopwatch = null)
+    public function __construct(StopwatchInterface $stopwatch = null)
     {
         /* REQUEST_TIME_FLOAT is closer to truth. */
         if (isset($_SERVER["REQUEST_TIME_FLOAT"])) {
@@ -63,7 +64,9 @@ class ServerTiming implements MiddlewareInterface
         /* Call all the other middlewares. */
         if ($this->process) {
             $this->stopwatch->start($this->process);
-            $response = $delegate->process($request);
+        }
+        $response = $delegate->process($request);
+        if ($this->process) {
             $this->stopwatch->stop($this->process);
         }
 

--- a/src/ServerTiming/QueryTimer.php
+++ b/src/ServerTiming/QueryTimer.php
@@ -21,7 +21,7 @@ class QueryTimer implements SQLLogger
 {
     public $stopwatch;
 
-    public function __construct(Stopwatch $stopwatch = null)
+    public function __construct(StopwatchInterface $stopwatch = null)
     {
         $this->stopwatch = $stopwatch;
     }

--- a/src/ServerTiming/Stopwatch.php
+++ b/src/ServerTiming/Stopwatch.php
@@ -17,9 +17,8 @@ namespace Tuupola\Middleware\ServerTiming;
 
 use Closure;
 use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopWatch;
-use Symfony\Component\Stopwatch\StopwatchEvent;
 
-class Stopwatch
+class Stopwatch implements StopwatchInterface
 {
     private $stopwatch = null;
     private $memory = null;

--- a/src/ServerTiming/StopwatchInterface.php
+++ b/src/ServerTiming/StopwatchInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Tuupola\Middleware\ServerTiming;
+
+
+use Closure;
+
+interface StopwatchInterface
+{
+    public function start($key);
+
+    public function stop($key);
+
+    public function stopAll();
+
+    public function closure($key, Closure $function = NULL);
+
+    public function set($key, $value = NULL);
+
+    public function get($key);
+
+    public function stopwatch();
+
+    public function memory();
+
+    public function values();
+}

--- a/src/ServerTiming/StopwatchInterface.php
+++ b/src/ServerTiming/StopwatchInterface.php
@@ -1,8 +1,19 @@
 <?php
 
+/*
+ * This file is part of the server timing middleware
+ *
+ * Copyright (c) 2017 Mika Tuupola
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *
+ * Project home:
+ *   https://github.com/tuupola/server-timing-middleware
+ *
+ */
 
 namespace Tuupola\Middleware\ServerTiming;
-
 
 use Closure;
 
@@ -14,9 +25,9 @@ interface StopwatchInterface
 
     public function stopAll();
 
-    public function closure($key, Closure $function = NULL);
+    public function closure($key, Closure $function = null);
 
-    public function set($key, $value = NULL);
+    public function set($key, $value = null);
 
     public function get($key);
 


### PR DESCRIPTION
Introduce & depend on StopwatchInterface, expose from ServerTiming to children.

This is so that a stub stopwatch can be substituted in production for uses of StopwatchInterface throughout the code and also passed to ServerTiming.