### PR TITLE
New header format

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You should now see the default timings when doing a request.
 $ curl --include http://localhost:8080
 
 HTTP/1.1 200 OK
-Server-Timing: Bootstrap=54, Process=2, Total=58
+Server-Timing: Bootstrap;dur=54, Process;dur=2, Total;dur=58
 ```
 
 Note that `ServerTimingMiddleware` must be added as last middleware. Otherwise timings will be inaccurate.
@@ -69,7 +69,7 @@ $app->add(new ServerTimingMiddleware(
 $ curl --include http://localhost:8080
 
 HTTP/1.1 200 OK
-Server-Timing: Startup=52, Sum=57
+Server-Timing: Startup;dur=52, Sum;dur=57
 ```
 
 ## Advanced usage
@@ -128,7 +128,7 @@ $app->run();
 $ curl --include http://0.0.0.0:8080/test
 
 HTTP/1.1 200 OK
-Server-Timing: Bootstrap=9, externalapi=101; "External API", Magic=50, SQL=34, Process=360, Total=369
+Server-Timing: Bootstrap;dur=9, externalapi;dur=101;desc="External API", Magic;dur=50, SQL;dur=34, Process;dur=360, Total;dur=369
 ```
 
 ## Usage with Doctrine DBAL

--- a/src/ServerTimingMiddleware.php
+++ b/src/ServerTimingMiddleware.php
@@ -88,9 +88,9 @@ final class ServerTimingMiddleware implements MiddlewareInterface
             if (preg_match($regex, $description)) {
                 $token = preg_replace($regex, "", $description);
                 $token = strtolower(trim($token, "-"));
-                $header .= sprintf('%s=%d; "%s", ', $token, $timing, $description);
+                $header .= sprintf('%s;dur=%d;desc="%s", ', $token, $timing, $description);
             } else {
-                $header .= sprintf("%s=%d, ", $description, $timing);
+                $header .= sprintf("%s;dur=%d, ", $description, $timing);
             }
         };
         return $header = preg_replace("/, $/", "", $header);

--- a/tests/ServerTimingTest.php
+++ b/tests/ServerTimingTest.php
@@ -47,7 +47,7 @@ class ServerTimingTest extends TestCase
         $response = $timing($request, $response, $next);
 
         $header = $response->getHeader("Server-Timing")[0];
-        $regex = "/Bootstrap=[0-9\.]+, Process=[0-9\.]+, Total=[0-9\.]+/";
+        $regex = "/Bootstrap;dur=[0-9\.]+, Process;dur=[0-9\.]+, Total;dur=[0-9\.]+/";
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("Success", $response->getBody());
@@ -72,7 +72,7 @@ class ServerTimingTest extends TestCase
         $response = $collection->dispatch($request, $default);
 
         $header = $response->getHeader("Server-Timing")[0];
-        $regex = "/Bootstrap=[0-9\.]+, Process=[0-9\.]+, Total=[0-9\.]+/";
+        $regex = "/Bootstrap;dur=[0-9\.]+, Process;dur=[0-9\.]+, Total;dur=[0-9\.]+/";
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("Success", $response->getBody());
@@ -99,7 +99,7 @@ class ServerTimingTest extends TestCase
         $response = $timing($request, $response, $next);
 
         $header = $response->getHeader("Server-Timing")[0];
-        $regexp = '/^dbserver=100; "DB Server", Bootstrap=[0-9]+, Process=[0-9]+, Total=[0-9]+/';
+        $regexp = '/^dbserver;dur=100;desc="DB Server", Bootstrap;dur=[0-9]+, Process;dur=[0-9]+, Total;dur=[0-9]+/';
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("Success", $response->getBody());
@@ -129,7 +129,7 @@ class ServerTimingTest extends TestCase
         $response = $timing($request, $response, $next);
 
         $header = $response->getHeader("Server-Timing")[0];
-        $regexp = '/^Startup=[0-9]+, Sum=[0-9]+/';
+        $regexp = '/^Startup;dur=[0-9]+, Sum;dur=[0-9]+/';
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals("Success", $response->getBody());


### PR DESCRIPTION
Addressing issue #5, as this has now dropped in the latest Canary. Updates middleware, tests and readme.