### PR TITLE
Allow installing with symfony/stopwatch:^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.2|^8.0",
         "phpstan/phpstan": "^1.8",
         "psr/http-server-middleware": "^1.0",
-        "symfony/stopwatch": "^4.0|^5.0|^6.0",
+        "symfony/stopwatch": "^4.0|^5.0|^6.0|^7.0",
         "tuupola/callable-handler": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
unit tests work (some deprecation alerts because of `assertRegExp()` being deprecated in PHPUnit 10)

fixes #26 